### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/gradlew-publish-and-deploy-app.yml
+++ b/.github/workflows/gradlew-publish-and-deploy-app.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: romanew/invest:latest
         username: ${{ secrets.DOCKER_PUBLISH_REGISTRY_USERNAME }}

--- a/.github/workflows/gradlew-publish-and-deploy-tests.yml
+++ b/.github/workflows/gradlew-publish-and-deploy-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: romanew/invest:latest-tests
           username: ${{ secrets.DOCKER_PUBLISH_REGISTRY_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore